### PR TITLE
#359 Add comment on required gem

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# RunDMC
+.# RunDMC
 
 ## NOTES
 
@@ -90,6 +90,16 @@ For example this command will rebuild the TOC.
     $ ./ml local deploy_docs --ml.build-actions=setup
 
 The available actions are implemented in `src/apidoc/setup.xqy`.
+
+#### Ruby gem Requirement
+
+You may receive an error if you do not have all required Ruby gems installed.  
+
+    ERROR: The net-http-digest_auth gem is required for this feature.
+
+net-http-digest_auth is required for deploy_docs.  To install this gem and proceed:
+    
+    $ sudo gem install net-http-digest_auth
 
 ## Servers
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-.# RunDMC
+# RunDMC
 
 ## NOTES
 


### PR DESCRIPTION
Add a comment that net-http-digest_auth is required to run deploy_docs
and how to add it if it is missing.