### PR TITLE
#338 Control publish/unpublish with roles

### DIFF
--- a/deploy/ml-config.xml
+++ b/deploy/ml-config.xml
@@ -707,6 +707,50 @@
         </privilege>
       </privileges>
     </role>
+    <role>
+      <role-name>dmc-author</role-name>
+      <description>An Author for RunDMC content</description>
+      <role-names>
+        <role-name>@ml.app-role</role-name>
+      </role-names>
+      <permissions>
+      </permissions>
+      <collections>
+      </collections>
+      <privileges>
+        <privilege>
+          <privilege-name>xdmp:xslt-invoke</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:filesystem-file-exists</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:document-get</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>xdmp:plan</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>any-uri</privilege-name>
+        </privilege>
+        <privilege>
+          <privilege-name>unprotected-collections</privilege-name>
+        </privilege>
+      </privileges>
+    </role>
+    <role>
+      <role-name>dmc-admin</role-name>
+      <description>An Admin for RunDMC content</description>
+      <role-names>
+        <role-name>dmc-author</role-name>
+      </role-names>
+      <permissions>
+      </permissions>
+      <collections>
+      </collections>
+      <privileges>
+      </privileges>
+    </role>
   </roles>
   <users xmlns="http://marklogic.com/xdmp/security">
     <user>
@@ -715,6 +759,7 @@
       <password>@ml.appuser-password</password>
       <role-names>
         <role-name>@ml.app-role</role-name>
+        <role-name>dmc-author</role-name>
       </role-names>
       <permissions/>
       <collections/>

--- a/src/admin/controller/modules/authorize.xqy
+++ b/src/admin/controller/modules/authorize.xqy
@@ -1,0 +1,17 @@
+xquery version "1.0-ml";
+
+module namespace authorize = "http://marklogic.com/rundmc/authorize";
+
+(: Determine if the currently logged in user has the admin role, either the MarkLogic
+ role or the DMC role. :)
+declare function authorize:is-admin() as xs:boolean*
+{
+  let $user-roles := xdmp:get-current-roles()
+  let $admin-roles := (xdmp:role("dmc-admin"), xdmp:role("admin"))
+  let $log := xdmp:log($user-roles)
+  return
+    if($user-roles = $admin-roles) then
+      true()
+    else
+      false()
+};

--- a/src/admin/controller/publish-unpublish-doc.xqy
+++ b/src/admin/controller/publish-unpublish-doc.xqy
@@ -1,6 +1,8 @@
 (: This script sets a document's status to either "Published" or "Draft". :)
 import module namespace param="http://marklogic.com/rundmc/params"
        at "../../controller/modules/params.xqy";
+import module namespace authorize="http://marklogic.com/rundmc/authorize"
+        at "modules/authorize.xqy";
 
 declare namespace map = "http://marklogic.com/xdmp/map";
 
@@ -13,6 +15,13 @@ let $redirect := string($params[@name eq 'redirect'])
 let $status   := if ($action eq "Publish")   then "Published"
             else if ($action eq "Unpublish") then "Draft"
             else error((), "Parameter 'action' must be either 'Publish' or 'Unpublish'")
+
+(: Ensure the user has the proper role in order to publish/unpublish :)
+let $authorized :=
+  if(authorize:is-admin()) then
+    ()
+  else
+    error((), fn:concat("User is not authorized to ", $action, " ", $params[@name eq 'path']))
 
 return
 (

--- a/src/admin/view/tag-library.xsl
+++ b/src/admin/view/tag-library.xsl
@@ -5,6 +5,7 @@
   xmlns      ="http://www.w3.org/1999/xhtml"
   xmlns:xhtml="http://www.w3.org/1999/xhtml"
   xmlns:srv="http://marklogic.com/rundmc/server-urls"
+  xmlns:authorize="http://marklogic.com/rundmc/authorize"
   xmlns:ml               ="http://developer.marklogic.com/site/internal"
   xpath-default-namespace="http://developer.marklogic.com/site/internal"
   exclude-result-prefixes="xs ml xdmp srv"
@@ -12,6 +13,7 @@
 
   <!-- Import the definition of $srv:draft-server and $srv:webdav-server -->
   <xdmp:import-module href="/controller/server-urls.xqy" namespace="http://marklogic.com/rundmc/server-urls"/>
+  <xdmp:import-module href="/admin/controller/modules/authorize.xqy" namespace="http://marklogic.com/rundmc/authorize"/>
 
   <xsl:template match="admin-page-listings">
     <table id="tbl_status">
@@ -167,12 +169,15 @@
                 <xsl:text>&#160;|&#160;</xsl:text>
                 <!-- TODO: make preview work -->
                 <a href="{$srv:draft-server}{substring-before(base-uri(.), '.xml')}" target="_blank">Preview</a>
-                <xsl:text>&#160;|&#160;</xsl:text>
+                <!-- Only show the Publish/Unpublish toggle if the user logged in is the proper role -->
+                <xsl:if test="authorize:is-admin()">
+                  <xsl:text>&#160;|&#160;</xsl:text>
 
-                <xsl:variable name="action" select="if (@status eq 'Published') then 'Unpublish' else 'Publish'"/>
-                <a href="/admin/controller/publish-unpublish-doc.xqy?path={base-uri(.)}&amp;action={$action}&amp;redirect={$current-page-url}">
-                  <xsl:value-of select="$action"/>
-                </a>
+                  <xsl:variable name="action" select="if (@status eq 'Published') then 'Unpublish' else 'Publish'"/>
+                    <a href="/admin/controller/publish-unpublish-doc.xqy?path={base-uri(.)}&amp;action={$action}&amp;redirect={$current-page-url}">
+                      <xsl:value-of select="$action"/>
+                    </a>
+                </xsl:if>
 
                 <!-- TODO: make remove work -->
                 <!-- Leave out "Remove" for v1.0


### PR DESCRIPTION
Add a dmc-admin and dmc-author role with proper privileges.  Use these
roles to control access to publishing and unpublishing content.  Add
new authorize module and function authorize:is-admin() to perform the
check of access level.  Add check to publish-unpublish-doc.xqy and also
show/hide link in UI based on role.