### PR TITLE
#363 Return both constrained and unconstrained totals from search.

### DIFF
--- a/src/controller/search.xqm
+++ b/src/controller/search.xqm
@@ -98,6 +98,7 @@ as xs:string
  : We want the constrained results,
  : but the facets should still be unconstrained.
  : To arrange this we search twice and merge the responses.
+ : Display uses both totals.
  :)
 declare function ss:search-response(
   $version as xs:string,
@@ -109,7 +110,7 @@ as element(search:response)
   element search:response {
     $response/@* ! (
       typeswitch(.)
-      case attribute(total) return ()
+      case attribute(total) return attribute facet-total { . }
       default return .),
     attribute query-unconstrained { $query },
     (: We also use the @total from the unconstrained facets,

--- a/src/view/search.xsl
+++ b/src/view/search.xsl
@@ -245,16 +245,20 @@
     <xsl:call-template name="did-you-mean">
       <xsl:with-param name="q" select="$QUERY"/>
     </xsl:call-template>
+    <xsl:variable name="total" as="xs:int"
+                  select="(@facet-total, @total)[1]"/>
     <xsl:variable name="last-in-full-page" select="@start + @page-length - 1"/>
-    <xsl:variable name="end-result-index"  select="if (@total lt @page-length or $last-in-full-page gt @total) then @total
-                                                   else $last-in-full-page"/>
+    <xsl:variable name="end-result-index"
+                  select="if ($total lt @page-length
+                          or $last-in-full-page gt $total) then $total
+                          else $last-in-full-page"/>
     <h3>
       <xsl:text>Results </xsl:text>
       <em>
         <xsl:value-of select="@start"/>–<xsl:value-of select="$end-result-index"/>
       </em>
       <xsl:text> of </xsl:text>
-      <xsl:value-of select="@total"/>
+      <xsl:value-of select="$total"/>
       <xsl:text> for </xsl:text>
       <em>
         <xsl:value-of select="search:qtext"/>
@@ -379,11 +383,13 @@
   </xsl:template>
 
   <xsl:template mode="prev-and-next" match="search:response">
+    <xsl:variable name="total" as="xs:int"
+                  select="(@facet-total, @total)[1]"/>
     <xsl:variable name="search-url" select="ml:external-uri(.)"/>
     <form class="pagination" action="/search" method="get">
       <div>
         <xsl:if test="$page-number gt 1">
-          <a class="prev"
+          <a class="prev" rel="prev"
              href="{
                    ss:href(
                    $PREFERRED-VERSION, $QUERY, $IS-API-SEARCH,
@@ -395,11 +401,11 @@
           <input name="p" type="text" value="{$page-number}" size="4"/>
           <input name="q" type="hidden" value="{$QUERY}"/>
           <xsl:text> of </xsl:text>
-          <xsl:value-of select="ceiling(@total div @page-length)"/>
+          <xsl:value-of select="ceiling($total div @page-length)"/>
         </label>
-        <xsl:if test="@total gt (@start + @page-length - 1)">
+        <xsl:if test="$total gt (@start + @page-length - 1)">
           <xsl:text> </xsl:text>
-          <a class="next"
+          <a class="next" rel="next"
              href="{
                    ss:href(
                    $PREFERRED-VERSION, $QUERY, $IS-API-SEARCH,


### PR DESCRIPTION
The model now returns @total and @facet-total in its XML response.
The view layer uses both totals to display pagination and facet controls.
Also added rel="next" and rel="prev" to pagination, for accessibility.