### PR TITLE
#358 search does not highlight if cookie cannot be set.

### DIFF
--- a/src/controller/search.xqm
+++ b/src/controller/search.xqm
@@ -176,6 +176,14 @@ as xs:string
   concat($name, '=', encode-for-uri($value))
 };
 
+declare function ss:query-string(
+  $params as xs:string*)
+as xs:string
+{
+  if (empty($params)) then ''
+  else string-join($params, '&amp;')
+};
+
 declare function ss:href(
   $version as xs:string,
   $query as xs:string,
@@ -186,13 +194,12 @@ as xs:string
   concat(
     $srv:search-page-url,
     '?',
-    string-join(
+    ss:query-string(
       (ss:param('q', $query),
         if (not($is-api)) then ()
         else ss:param($ss:INPUT-NAME-API, xs:string($is-api)),
         ss:param($ss:INPUT-NAME-API-VERSION, $version),
-        ss:param('p', xs:string($page))),
-      '&amp;'))
+        ss:param('p', xs:string($page)))))
 };
 
 declare function ss:href(
@@ -202,6 +209,27 @@ declare function ss:href(
 as xs:string
 {
   ss:href($version, $query, $is-api, ())
+};
+
+declare function ss:result-uri(
+  $uri as xs:string,
+  $highlight-query as xs:string?,
+  $is-api-doc as xs:boolean,
+  $api-version-prefix as xs:string)
+as xs:string
+{
+  concat(
+    if (not($is-api-doc)) then ml:external-uri-main($uri)
+    else concat(
+      $srv:effective-api-server,
+      $api-version-prefix,
+      ml:external-uri-for-string(ss:rewrite-html-links($uri))),
+    (: Add the highlight param if needed.
+     : The external-uri-main function never adds a query string,
+     : so we have a free hand.
+     :)
+    if (not($highlight-query)) then ''
+    else concat('?', ss:query-string(ss:param('hq', $highlight-query))))
 };
 
 (: search.xqm :)

--- a/src/view/page.xsl
+++ b/src/view/page.xsl
@@ -47,13 +47,15 @@
 
   <xsl:variable name="original-content" select="/"/>
 
-  <xsl:variable name="highlight-search" select="string($latest-search-qtext)"/>
   <xsl:variable name="content"
-                select="if ($highlight-search) then $highlighted-content else /"/>
+                select="if ($HIGHLIGHT-QUERY) then $highlighted-content
+                        else /"/>
 
-          <xsl:variable name="highlighted-content">
-            <xsl:apply-templates mode="preserve-base-uri" select="u:highlight-doc(/, $highlight-search, ml:external-uri(/))"/>
-          </xsl:variable>
+  <xsl:variable name="highlighted-content">
+    <xsl:apply-templates mode="preserve-base-uri"
+                         select="u:highlight-doc(
+                                 /, $HIGHLIGHT-QUERY, ml:external-uri(/))"/>
+  </xsl:variable>
 
                   <xsl:template mode="preserve-base-uri" match="@* | node()">
                     <xsl:copy>
@@ -112,10 +114,6 @@
     <!-- XSLT BUG WORKAROUND (outputs nothing); works because it apparently forces evaluation earlier -->
     <xsl:value-of select="$content/.."/> <!-- empty sequence -->
     <xsl:value-of select="substring-after($external-uri,$external-uri)"/> <!-- empty string -->
-
-    <!-- Don't ever keep the temporary search highlight cookie around. -->
-    <xsl:value-of select="$_reset-search-cookie"/>
-
     <xsl:apply-templates select="$template/*"/>
   </xsl:template>
 

--- a/src/view/search.xsl
+++ b/src/view/search.xsl
@@ -42,11 +42,12 @@
                 select="if ($PREFERRED-VERSION eq $ml:default-version) then ''
                         else concat('/',$PREFERRED-VERSION)"/>
 
-  <!-- This is used for hit highlighting. Only available when the client sets it (on the search results page) -->
-  <xsl:variable name="latest-search-qtext" select="ck:get-cookie('search-qtext')[1]"/>
-
   <xsl:variable name="QUERY" as="xs:string"
                 select="string-join($params[@name eq 'q'], ' ')"/>
+
+  <!-- If set, use this value to highlight matches. -->
+  <xsl:variable name="HIGHLIGHT-QUERY" as="xs:string?"
+                select="string-join($params[@name eq 'hq'], ' ')"/>
 
   <xsl:variable name="SEARCH-RESPONSE" as="element(search:response)">
     <xsl:variable name="results-per-page" select="10"/>
@@ -86,11 +87,6 @@
                         $srv:cookie-domain,
                         '/',
                         false())"/>
-
-  <!-- This must be evaluated for every page, to prevent continued (unwanted) highlighting (see page.xsl) -->
-  <xsl:variable name="_reset-search-cookie"
-                select="ck:delete-cookie('search-qtext', $srv:cookie-domain, '/')"/>
-
 
   <!-- Overriden by apidoc/view/page.xsl so this has to use XSL. -->
   <xsl:function name="ml:version-is-selected" as="xs:boolean">
@@ -265,31 +261,17 @@
       <xsl:apply-templates mode="#current" select="search:result"/>
     </table>
     <xsl:apply-templates mode="prev-and-next" select="."/>
-
-    <!-- We set the search qtext on click to a cookie to enable highlighting on the next page only. -->
-    <script type="text/javascript">
-      //<xsl:comment>
-      $("a.search_result").click(function(){
-      $.cookie("search-qtext",
-      "<xsl:value-of select="replace($QUERY-UNCONSTRAINED,'&quot;','\\&quot;')"/>", <!-- js-escape quotes -->
-      {"domain":"<xsl:value-of select="$srv:cookie-domain"/>", "path":"/"});
-      });
-      //</xsl:comment>
-    </script>
   </xsl:template>
 
   <!-- Render one result from a search:response. -->
   <xsl:template mode="search-results" match="search:result">
     <xsl:variable name="doc" select="doc(@uri)"/>
-    <xsl:variable name="is-api-doc" select="starts-with(@uri,'/apidoc/')"/>
-    <xsl:variable name="anchor"
-                  select="if ($doc/*:chapter) then '' else ''"/>
     <xsl:variable name="result-uri"
-                  select="if ($is-api-doc) then concat(
-                          $srv:effective-api-server, $API-VERSION-PREFIX,
-                          ml:external-uri-for-string(ss:rewrite-html-links(@uri)),
-                          $anchor)
-                          else ml:external-uri-main(@uri)"/>
+                  select="ss:result-uri(
+                          @uri,
+                          $QUERY-UNCONSTRAINED,
+                          starts-with(@uri, '/apidoc/'),
+                          $API-VERSION-PREFIX)"/>
     <tr>
       <th>
         <xsl:variable name="category">


### PR DESCRIPTION
Per discussion in the issue tracker,
setting a cookie on an IP address or short hostname
is not permitted by RFC6265. Rather than require dev environments
to have and set a FQDN in `server-urls.xml`,
This patch moves the highlight-query functionality
into a new param `hq`.