### PR TITLE
Add the version widget to the breadcrumb display for API search

### DIFF
--- a/src/view/search.xsl
+++ b/src/view/search.xsl
@@ -530,6 +530,7 @@
       <xsl:with-param name="site-name" select="'Docs'"/>
       <xsl:with-param name="version" select="$PREFERRED-VERSION"/>
     </xsl:apply-templates>
+    <xsl:apply-templates mode="version-list" select="."/>
   </xsl:template>
 
 </xsl:stylesheet>


### PR DESCRIPTION
#366 Add the version widget to the breadcrumb display on API-specific search results pages.