### PR TITLE
#338 Add document permissions

### DIFF
--- a/src/admin/controller/create.xqy
+++ b/src/admin/controller/create.xqy
@@ -10,6 +10,9 @@ import module namespace param="http://marklogic.com/rundmc/params"
 import module namespace ml="http://developer.marklogic.com/site/internal"
        at "../../model/data-access.xqy";
 
+import module namespace admin-ops = "http://marklogic.com/rundmc/admin-ops"
+       at "modules/admin-ops.xqy";
+
 let $params      := param:params()
 let $new-doc-url := $params[@name eq '~new_doc_url']
 let $map         := map:map()
@@ -22,7 +25,7 @@ let $new-doc     := xdmp:xslt-invoke("../model/form2xml.xsl",
 return
 (
   (: Insert the new document :)
-  xdmp:document-insert($new-doc-url, $new-doc),
+  admin-ops:document-insert($new-doc-url, $new-doc),
 
   ml:reset-category-tags($new-doc-url, $new-doc),
 

--- a/src/admin/controller/modules/admin-ops.xqy
+++ b/src/admin/controller/modules/admin-ops.xqy
@@ -1,0 +1,32 @@
+xquery version "1.0-ml";
+
+module namespace admin-ops = "http://marklogic.com/rundmc/admin-ops";
+
+
+declare function admin-ops:document-insert(
+  $uri as xs:string,
+  $doc as node()
+)
+as empty-sequence()
+{
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions()
+  )
+};
+
+declare function admin-ops:document-insert(
+  $uri as xs:string,
+  $doc as node(),
+  $collections as xs:string*
+)
+as empty-sequence()
+{
+  xdmp:document-insert(
+    $uri,
+    $doc,
+    xdmp:default-permissions(),
+    $collections
+  )
+};

--- a/src/admin/controller/preview.xqy
+++ b/src/admin/controller/preview.xqy
@@ -11,6 +11,9 @@ import module namespace param="http://marklogic.com/rundmc/params"
 import module namespace srv="http://marklogic.com/rundmc/server-urls"
        at "../../controller/server-urls.xqy";
 
+import module namespace admin-ops = "http://marklogic.com/rundmc/admin-ops"
+       at "modules/admin-ops.xqy";
+
 let $params  := param:params()
 let $map     := map:map()
 
@@ -28,7 +31,7 @@ return
     return
     (
       (: Insert the document, after marking it as "preview-only" :)
-      xdmp:document-insert($doc-url, xdmp:xslt-invoke("../model/set-doc-attribute.xsl", $new-doc, (map:put($map, "att-name", "preview-only"),
+      admin-ops:document-insert($doc-url, xdmp:xslt-invoke("../model/set-doc-attribute.xsl", $new-doc, (map:put($map, "att-name", "preview-only"),
                                                                                                    map:put($map, "att-value", "yes"),
                                                                                                    $map))),
 

--- a/src/admin/controller/replace.xqy
+++ b/src/admin/controller/replace.xqy
@@ -7,6 +7,9 @@ import module namespace param="http://marklogic.com/rundmc/params"
 import module namespace ml="http://developer.marklogic.com/site/internal"
        at "../../model/data-access.xqy";
 
+import module namespace admin-ops = "http://marklogic.com/rundmc/admin-ops"
+       at "modules/admin-ops.xqy";
+
 let $params  := param:params()
 let $map     := map:map()
 
@@ -20,7 +23,7 @@ return
     if (normalize-space($existing-doc-path) and doc-available($existing-doc-path))
     then (
            (: Replace the existing document :)
-           xdmp:document-insert($existing-doc-path, $new-doc),
+           admin-ops:document-insert($existing-doc-path, $new-doc),
 
            ml:reset-category-tags($existing-doc-path, $new-doc),
 

--- a/src/admin/controller/upload.xqy
+++ b/src/admin/controller/upload.xqy
@@ -1,5 +1,8 @@
 xquery version "1.0-ml";
 
+import module namespace admin-ops = "http://marklogic.com/rundmc/admin-ops"
+       at "modules/admin-ops.xqy";
+
 declare variable $content := xdmp:get-request-field("content");
 
 declare variable $uri := "/media/" || xdmp:get-request-field("uri");
@@ -9,10 +12,9 @@ declare variable $overwrite := fn:boolean(xdmp:get-request-field("overwrite"));
 if (fn:doc-available($uri) and fn:not($overwrite)) then
   fn:error(xs:QName("Conflict"), "Something already exists at URI " || $uri)
 else (
-  xdmp:document-insert(
+  admin-ops:document-insert(
     $uri,
     $content,
-    xdmp:default-permissions(),
     "media"
   ),
   xdmp:redirect-response("/media")


### PR DESCRIPTION
Wrap all xdmp:document-inserts performed by the Admin application to
provide default document permissions rather than none.

Add a new admin-ops.xqy module that has the document-insert wrapper
functions.  This module can grow over time if more wrapping needs to
happen in the Admin controller.