### PR TITLE
#354 Update key

### DIFF
--- a/src/stackunderflow/stackunderflow-1.0.3.js
+++ b/src/stackunderflow/stackunderflow-1.0.3.js
@@ -184,7 +184,7 @@ function execQuestions(url, params, complete) {
 }
 
 var su = window.stackunderflow = {
-    appId: "",
+    appId: "tLFdXCh*Rz*A2zKe17*few((",
     site: "http://stackoverflow.com",
     loaded: function(callback) {
         if (isLoaded) {


### PR DESCRIPTION
Per StackExchange documentation, the API key used by an application
“is not considered a secret, and may be safely embed in client side
code or distributed binaries.”  Adding back in key.