### PR TITLE
Fix for license 404

### DIFF
--- a/src/apidoc/setup/toc.xqm
+++ b/src/apidoc/setup/toc.xqm
@@ -24,8 +24,8 @@ import module namespace raw="http://marklogic.com/rundmc/raw-docs-access"
 (: The help page code relies on undocumented and unsupported functions
  : found in the MarkLogic admin UI code.
  :)
-import module namespace af="http://marklogic.com/xdmp/admin/admin-forms"
-  at "/MarkLogic/admin/admin-forms.xqy" ;
+import module namespace af="http://www.w3.org/2003/05/xpath-functions"
+  at "/MarkLogic/Admin/lib/admin-forms.xqy" ;
 
 declare namespace apidoc="http://marklogic.com/xdmp/apidoc" ;
 

--- a/src/controller/rewrite.xqm
+++ b/src/controller/rewrite.xqm
@@ -402,7 +402,7 @@ as xs:string
     else if ($path eq "/validate") then concat(
       "/controller/validate.xqy?", $query-string)
     else if ($path eq "/process-license-request") then concat(
-      "/controller/process-lrequest.xqy?", $query-string)
+      "/controller/process-license-request.xqy?", $query-string)
     else if ($path eq "/process-license-request-2") then concat(
       "/controller/process-license-request-2.xqy?", $query-string)
     else if ($path eq "/license-record") then concat(

--- a/src/test/main-controller.xqm
+++ b/src/test/main-controller.xqm
@@ -15,9 +15,9 @@ declare %t:case function t:main-controller-300()
 {
   at:equal(
     ml:version-select(
-      (<param name="v">7.0</param>,
+      (<param name="v">{ $ml:default-version }</param>,
         <param name="v"/>)),
-    '7.0')
+    $ml:default-version)
 };
 
 (: test/search.xqm :)

--- a/src/test/main-rewrite.xqm
+++ b/src/test/main-rewrite.xqm
@@ -14,13 +14,15 @@ import module namespace rw="http://marklogic.com/rundmc/rewrite"
 declare variable $NOTFOUND := (
   '/controller/301redirect.xqy?path=/controller/notfound.xqy') ;
 
+declare variable $BASE := 'http://developer.marklogic.com' ;
+
 declare %t:case function t:guide-296()
 {
   at:equal(
     rw:rewrite(
       'GET',
       '/pubs/3.2/books/install.pdf',
-      'http://developer.marklogic.com/pubs/3.2/books/install.pdf',
+      $BASE||'/pubs/3.2/books/install.pdf',
       ''),
     '/controller/301redirect.xqy?path=//localhost:8809/guide/installation.pdf')
 };
@@ -31,9 +33,21 @@ declare %t:case function t:guide-299()
     rw:rewrite(
       'GET',
       '/pubs/2.2/books/dev',
-      'http://developer.marklogic.com/pubs/2.2/books/dev',
+      $BASE||'/pubs/2.2/books/dev',
       ''),
     $NOTFOUND)
+};
+
+declare %t:case function t:license()
+{
+  ('/process-license-request'
+    ||'?r=http%3a//mint.marklogic.com/5X/demo-keygen-5.X.xqy')
+  ! rw:rewrite(
+    'GET', substring-before(., '?'), $BASE||., substring-after(., '?'))
+  ! at:equal(
+    .,
+    '/controller/process-license-request.xqy'
+    ||'?r=http%3a//mint.marklogic.com/5X/demo-keygen-5.X.xqy')
 };
 
 (: test/apidoc-rewrite.xqm :)


### PR DESCRIPTION
See http://markmail.org/message/s4dmur6d5m2pjtdu for the report. This reverts what looks like a typo in c219919dd5c3e21bdd9a0a405e942409ab82e339 and adds a test case.

This also includes some ML8 compatibility work, because I couldn't test without it. If you want to minimize changes, the diff for `src/controller/rewrite.xqm` should be enough.