### PR TITLE
#452 Validate possible XHTML content in a textarea before submit

### DIFF
--- a/src/admin/config/template.xhtml
+++ b/src/admin/config/template.xhtml
@@ -25,6 +25,57 @@
            }
        }
 
+       function checkValidXhtml(action, target) {
+          // Event has more than one TEXTAREA, so we need to loop.
+          var textAreas = document.getElementsByTagName("TEXTAREA");
+          var textAreasLength = textAreas.length;
+          var isValid = false;
+          $.each(textAreas, function(index, value)
+            {
+            $.ajax({
+              url: '/admin/controller/validate.xqy',
+              type: "POST",
+              data: {
+                xhtml: value.value
+              },
+              cache: false,
+              dataType: "text",
+              success:
+                function(response)
+                {
+                  // If we get a null response (empty sequence), the textarea validates.  Allow form to continue.
+                  if(!response)  {
+                    console.log('XHTML is good!');
+                    // Clear any existing errors
+                    // Allow form submission to continue
+                    var adminform = document.getElementsByClassName('adminform')[0];
+                    adminform.action = action;
+                    adminform.target = target;
+                    adminform.submit();
+                    isValid = true;
+                  }
+                  else {
+                    // Bad XHTML or another problem.  Display this error:error node back to the user.
+                    var errorDiv = document.getElementById('textarea-error');
+                    errorDiv.innerHTML +=  "There was a problem with your content. Error from the Server: " + response;
+                    errorDiv.style.display = 'block';
+                    console.log(response);
+                    isValid = false;
+                  }
+
+                },
+              error:
+                function(xml) {
+                  var errorDiv = document.getElementById('textarea-error');
+                  errorDiv.innerHTML += "There was unexpected problem in the Server: " + xml;
+                  errorDiv.style.display = 'block';
+                  isValid = false;
+                }
+            });
+          });
+          return isValid;
+       }
+
        $(document).ready(function() {
 
            tinyMCE.init({
@@ -34,7 +85,7 @@
             editor_selector : "richtext",
             theme : "advanced",
             plugins : "safari,spellchecker,pagebreak,style,layer,table,save,advhr,advimage,advlink,emotions,iespell,inlinepopups,insertdatetime,preview,media,searchreplace,print,contextmenu,paste,directionality,fullscreen,noneditable,visualchars,nonbreaking,xhtmlxtras",
-             
+
             // Theme options
             theme_advanced_buttons1 : "bold,italic,underline,strikethrough,|,justifyleft,justifycenter,justifyright,justifyfull,|,formatselect,fontselect,fontsizeselect",
             theme_advanced_buttons2 : "cut,copy,paste,pastetext,pasteword,|,search,replace,|,bullist,numlist,|,outdent,indent,blockquote,|,undo,redo,|,link,unlink,anchor,image,cleanup,help,code,|,insertdate,inserttime,preview,|,forecolor,backcolor",
@@ -44,7 +95,7 @@
             theme_advanced_toolbar_align : "left",
             theme_advanced_statusbar_location : "bottom",
             theme_advanced_resizing : true,
-             
+
             entity_encoding : "numeric",
             extended_valid_elements : 'ml:teaser,ml:tabbed-features,ml:feature[href],ml:short-description,ml:product-info[name|license-page|requirements-page],ml:platform[name],ml:download[href|size|date],ml:product-documentation,ml:old-doc[desc|path],ml:doc[source],product-info[name|license-page|requirements-page],platform[name],download[href|size|date],product-documentation,old-doc[desc|path],doc[source],figure[id]',
             custom_elements:          'ml:teaser,ml:tabbed-features,~ml:feature,ml:short-description,ml:platform,ml:download,ml:product-documentation,ml:old-doc,ml:doc,ml:product-info,platform,download,product-documentation,old-doc,doc,product-info',

--- a/src/admin/controller/validate.xqy
+++ b/src/admin/controller/validate.xqy
@@ -1,0 +1,22 @@
+xquery version "1.0-ml";
+
+declare namespace error="http://marklogic.com/xdmp/error";
+
+declare variable $xhtml := xdmp:get-request-field("xhtml");
+
+(: Determine if some XHTML is valid.  Wrap it in a document wrapper and see if it can be unquoted.
+    This will generate meaningful errors of the XHTML is invalid :)
+let $test-xhtml :=
+  try {
+    let $quoted-doc := fn:concat('&lt;docWrapper>', $xhtml, '&lt;/docWrapper>')
+    return xdmp:unquote($quoted-doc, 'http://www.w3.org/1999/xhtml')
+  }
+  catch($exception) {
+    $exception
+  }
+
+return
+  if(fn:node-name($test-xhtml) = xs:QName("error:error")) then
+    $test-xhtml
+  else
+    ()

--- a/src/admin/view/form.xsl
+++ b/src/admin/view/form.xsl
@@ -149,7 +149,7 @@
                   <strong>OOPS:</strong>
                   <xsl:choose>
                     <xsl:when test="$error-code eq 'no-slug'">
-                      You must specify a URI path. 
+                      You must specify a URI path.
                     </xsl:when>
                     <xsl:when test="$error-code eq 'doc-exists'">
                       A document at this URI already exists.<br />
@@ -199,13 +199,13 @@
               <xsl:apply-templates mode="labeled-controls" select="."/>
               <xsl:choose>
                 <xsl:when test="string($doc-path)">
-                  <input type="submit" name="submit" value="Save changes"  onclick="this.form.action = '/admin/controller/replace.xqy'; this.form.target = '_self';"/>
+                  <input type="submit" name="submitSave" value="Save changes"  onclick="return checkValidXhtml('/admin/controller/replace.xqy', '_self');"/>
                 </xsl:when>
                 <xsl:otherwise>
-                  <input type="submit" name="submit" value="Submit document" onclick="this.form.action = '/admin/controller/create.xqy'; this.form.target = '_self';"/>
+                  <input type="submit" name="submitBtn" value="Submit document" onclick="return checkValidXhtml('/admin/controller/create.xqy', '_self');"/>
                 </xsl:otherwise>
               </xsl:choose>
-              <input type="submit" name="submit" value="Preview changes" onclick="this.form.action = '/admin/controller/preview.xqy'; this.form.target = '_blank';"/>
+              <input type="submit" name="submitPreview" value="Preview changes" onclick="teturn checkValidXhtml('/admin/controller/preview.xqy', '_blank');"/>
             </form>
           </xsl:template>
 
@@ -343,6 +343,7 @@
                                       <br/>
                                       -->
                                       <div id="control-container" style="margin-left: 112px;">
+                                      <div id="textarea-error" class="error" style="display: none;"/>
                                       <textarea id="{form:field-name(.)}_{$textarea-id}"
                                                 name="{form:field-name(.)}"
                                                 style="width: 100%"


### PR DESCRIPTION
Before an create or edit form submit with textarea content, POST to a new validate.xqy.  This will wrap the textarea contents in a quoted docWrapper node and attempt to unquote it (like form2xml.xsl does).  If any error condition occurs, return that error:error node and display it back to the user.  If it unquotes cleanly, return an empty sequence and let the form continue its submit.