### PR TITLE
Issue452 - Bugfixes introduced by 50fb7b4

### DIFF
--- a/src/admin/config/template.xhtml
+++ b/src/admin/config/template.xhtml
@@ -29,7 +29,7 @@
           // Event has more than one TEXTAREA, so we need to loop.
           var textAreas = document.getElementsByTagName("TEXTAREA");
           var textAreasLength = textAreas.length;
-          var isValid = false;
+          var isValid = true;
           $.each(textAreas, function(index, value)
             {
             $.ajax({
@@ -40,26 +40,16 @@
               },
               cache: false,
               dataType: "text",
+              async: false,
               success:
                 function(response)
                 {
-                  // If we get a null response (empty sequence), the textarea validates.  Allow form to continue.
-                  if(!response)  {
-                    console.log('XHTML is good!');
-                    // Clear any existing errors
-                    // Allow form submission to continue
-                    var adminform = document.getElementsByClassName('adminform')[0];
-                    adminform.action = action;
-                    adminform.target = target;
-                    adminform.submit();
-                    isValid = true;
-                  }
-                  else {
+                  // If we get a response, something is wrong with the content
+                  if(response)  {
                     // Bad XHTML or another problem.  Display this error:error node back to the user.
                     var errorDiv = document.getElementById('textarea-error');
                     errorDiv.innerHTML +=  "There was a problem with your content. Error from the Server: " + response;
                     errorDiv.style.display = 'block';
-                    console.log(response);
                     isValid = false;
                   }
 
@@ -73,6 +63,15 @@
                 }
             });
           });
+
+          // No problem in the textareas, allow form submission to continue
+          if(isValid) {
+            var adminform = document.getElementsByClassName('adminform')[0];
+            adminform.action = action;
+            adminform.target = target;
+            adminform.submit();
+          }
+
           return isValid;
        }
 

--- a/src/admin/view/form.xsl
+++ b/src/admin/view/form.xsl
@@ -205,7 +205,7 @@
                   <input type="submit" name="submitBtn" value="Submit document" onclick="return checkValidXhtml('/admin/controller/create.xqy', '_self');"/>
                 </xsl:otherwise>
               </xsl:choose>
-              <input type="submit" name="submitPreview" value="Preview changes" onclick="teturn checkValidXhtml('/admin/controller/preview.xqy', '_blank');"/>
+              <input type="submit" name="submitPreview" value="Preview changes" onclick="return checkValidXhtml('/admin/controller/preview.xqy', '_blank');"/>
             </form>
           </xsl:template>
 


### PR DESCRIPTION
Fix logic for more than one textarea.  Prior logic would have allowed one good field to "dominate" and ignore an error in another textarea.  Now all textareas must be valid.  Also fix a typo in a return statement.