### PR TITLE
#349 Do not display the entire contents of a blog post

### DIFF
--- a/src/view/page.xsl
+++ b/src/view/page.xsl
@@ -428,7 +428,8 @@
         <xsl:apply-templates select="short-description/node()"/>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:value-of select="substring(body/node(), 1, 999 + string-length(substring-before(substring(body/node(), 1000),' ')))" />
+        <xsl:variable name="stringList" select="tokenize(body, ' ')" />
+         <xsl:value-of select="substring(body/string(), 1, 999 + string-length(substring-before(substring(body/string(), 1000),' ')))" />
         <a href="{ml:external-uri(.)}"> ...</a>
       </xsl:otherwise>
     </xsl:choose>

--- a/src/view/page.xsl
+++ b/src/view/page.xsl
@@ -385,7 +385,17 @@
       </header>
 
       <div class="body">
-        <xsl:apply-templates mode="post-content" select="."/>
+        <!-- Display an abridged version of a post if we're on a list with more than one;
+             otherwise, show the entire post.
+        -->
+        <xsl:choose>
+          <xsl:when test="$in-paginated-list">
+            <xsl:apply-templates mode="post-content-abridged" select="."/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates mode="post-content" select="."/>
+          </xsl:otherwise>
+        </xsl:choose>
       </div>
 
     </article>
@@ -408,6 +418,20 @@
 
   <xsl:template mode="post-content" match="Post | Announcement">
     <xsl:apply-templates select="body/node()"/>
+  </xsl:template>
+
+  <xsl:template mode="post-content-abridged" match="Post | Announcement">
+    <xsl:choose>
+      <!-- Show the short-description if it exists, otherwise show the first 1000 characters but
+            make sure you don't chop off a word -->
+      <xsl:when test="short-description ne ''">
+        <xsl:apply-templates select="short-description/node()"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="substring(body/node(), 1, 999 + string-length(substring-before(substring(body/node(), 1000),' ')))" />
+        <a href="{ml:external-uri(.)}"> ...</a>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template mode="post-content" match="Event">


### PR DESCRIPTION
Limit the blog summary page to to display either the post's short-description or, in the absence of this element value, truncate the blog post to the first 1000 chars. If that happens to fall on a word, look for the next space char before truncating.  Cast the node to a string to handle the case where HTML is part of the body.