### PR TITLE
#465 Properly handle namespace when checking XHTML validity

### DIFF
--- a/src/admin/controller/validate.xqy
+++ b/src/admin/controller/validate.xqy
@@ -8,8 +8,8 @@ declare variable $xhtml := xdmp:get-request-field("xhtml");
     This will generate meaningful errors of the XHTML is invalid :)
 let $test-xhtml :=
   try {
-    let $quoted-doc := fn:concat('&lt;docWrapper>', $xhtml, '&lt;/docWrapper>')
-    return xdmp:unquote($quoted-doc, 'http://www.w3.org/1999/xhtml')
+    let $quoted-doc := fn:concat("&lt;ml:docWrapper xmlns:ml='http://developer.marklogic.com/site/internal'>", $xhtml, "&lt;/ml:docWrapper>")
+    return xdmp:unquote($quoted-doc, "http://www.w3.org/1999/xhtml")
   }
   catch($exception) {
     $exception


### PR DESCRIPTION
Explicitly declare and use the ml namespace for the docWrapper used to check validity of XHTML content. 