### PR TITLE
#473 developer site - Fix drop-down from button with user's name

### DIFF
--- a/src/css/screen.css
+++ b/src/css/screen.css
@@ -2766,12 +2766,12 @@ div.header-separator {
 #session-menu {
     right: 316px;
     width: 102px;
+    background-color: black;
 }
 
 .drop-down-menu a,
 #session-menu a {
-    color: #565656;
-    text-shadow: 1px 1px #FFF;
+    color: white;
     text-decoration: none;
 }
 


### PR DESCRIPTION
Fix the CSS on the drop-down below the button with the user's name.  Background is now black (not transparent), matching the login box drop-down.  Also, text is solid white without shadow, also matching the login box color.