### PR TITLE
#489 specify the dataType

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -747,6 +747,7 @@ function loadRecentContent() {
   };
   $.ajax({
     url: '/recent',
+    dataType: 'json',
     success: function(data) {
       var recent = $('#recent');
       data.forEach(function(item) {


### PR DESCRIPTION
I had left  this out and on localhost, jQuery successfully guessed that
the data was JSON. On dmc-stage, it wasn't able to guess that. Tests on
dmc-stage show that once it's specified, the code works.