### PR TITLE
Making buildCodeMirror() callable from posts

### DIFF
--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -347,25 +347,6 @@ if(typeof jQuery != 'undefined') {
         .append($('<div>', {'class': 'shadow'}));
     }
 
-    // Give your textarea two classes: 'codemirror' and a mode. For instance,
-    // <textarea class="codemirror xml">...</textarea>
-    // Then call codeMirror.apply('xml');, adding any desired options.
-    function buildCodeMirror(className, options) {
-      var elements = document.getElementsByClassName('codemirror ' + className);
-      var codeOptions = {
-        lineNumbers: true,
-        mode: className,
-        readOnly: true,
-        theme: 'default'
-      };
-      if (elements.length > 0) {
-        $.extend(codeOptions, options);
-        Array.prototype.forEach.call(elements, function(item) {
-          CodeMirror.fromTextArea(item, codeOptions);
-        });
-      }
-    }
-
     $(document).ready(function() {
 
       var container = document.getElementById("home-tabs");
@@ -739,6 +720,26 @@ if(typeof jQuery != 'undefined') {
     // add new functions before this comment
   });
 }
+
+// Give your textarea two classes: 'codemirror' and a mode. For instance,
+// <textarea class="codemirror xml">...</textarea>
+// Then call codeMirror.apply('xml');, adding any desired options.
+function buildCodeMirror(className, options) {
+  var elements = document.getElementsByClassName('codemirror ' + className);
+  var codeOptions = {
+    lineNumbers: true,
+    mode: className,
+    readOnly: true,
+    theme: 'default'
+  };
+  if (elements.length > 0) {
+    $.extend(codeOptions, options);
+    Array.prototype.forEach.call(elements, function(item) {
+      CodeMirror.fromTextArea(item, codeOptions);
+    });
+  }
+}
+
 
 function loadRecentContent() {
   var icons = {


### PR DESCRIPTION
By making this function available from anywhere, a post that wants to use a CodeMirror mode that isn't provided by default can simply call it from the post itself. For instance:

    <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.4.0/mode/sparql/sparql.min.js" xml:space="preserve"></script>
    <script xml:space="preserve">buildCodeMirror('sparql', null);</script>
