### PR TITLE
updating copyright notice to match www.marklogic.com

### DIFF
--- a/src/apidoc/view/page.xsl
+++ b/src/apidoc/view/page.xsl
@@ -133,6 +133,13 @@
 
   <xsl:template match="ml:apidoc-copyright" name="apidoc-copyright">
     <xsl:copy-of select="v:apidoc-copyright()"/>
+    <div id="terms">
+      Powered by <a href="//developer.marklogic.com/products">MarkLogic Server
+      <span class="server-version"><xsl:copy-of select="xdmp:version()"/></span></a> and
+      <a href="//developer.marklogic.com/code/rundmc">rundmc</a> |
+      <a href="http://www.marklogic.com/terms-of-use/">Terms of Use</a> |
+      <a href="http://www.marklogic.com/privacy-policy/">Privacy Policy</a>
+    </div>
   </xsl:template>
 
   <xsl:template mode="print-view" match="*">

--- a/src/apidoc/view/view.xqm
+++ b/src/apidoc/view/view.xqm
@@ -87,13 +87,9 @@ as element()
 {
   (: Use absolute links so they work uniformly on standalone docs app. :)
   <div xmlns="http://www.w3.org/1999/xhtml"
-  id="copyright">Copyright &#169; 2017 MarkLogic Corporation. All rights reserved.
-  | Powered by
-  <a href="//developer.marklogic.com/products">
-  MarkLogic Server
-  <span class="server-version">{ xdmp:version() }</span>
-  </a>
-  and <a href="//developer.marklogic.com/code/rundmc">rundmc</a>.
+  id="copyright">
+    Copyright © 2017 MarkLogic Corporation. MARKLOGIC is a
+    registered trademark of MarkLogic Corporation.
   </div>
 };
 

--- a/src/css/apidoc.css
+++ b/src/css/apidoc.css
@@ -97,7 +97,14 @@ ol ol {
     clear: both;
     font-size: 11px;
     text-align: center;
-    padding: 20px;
+    padding: 20px 20px 0 20px;
+}
+
+#terms {
+    clear: both;
+    font-size: 11px;
+    text-align: center;
+    padding: 0 20px 20px 20px;
 }
 
 #breadcrumb,

--- a/src/view/tag-library.xsl
+++ b/src/view/tag-library.xsl
@@ -1265,7 +1265,7 @@
   <xsl:template match="copyright">
     <p align="center" id="copyright">Copyright ©
       <xsl:value-of select="fn:year-from-date(fn:current-date())"/>
-      MarkLogic Corporation. All rights reserved.
+      MarkLogic Corporation. MARKLOGIC is a registered trademark of MarkLogic Corporation.
     </p>
   </xsl:template>
 


### PR DESCRIPTION
I was asked to update the dev & docs copyright notice to match the one on www.marklogic.com. 