### PR TITLE
664: provide a feed for recipes

### DIFF
--- a/src/controller/rewrite.xqm
+++ b/src/controller/rewrite.xqm
@@ -400,6 +400,8 @@ as xs:string
       and ml:doc-matches-dmc-page-or-preview(doc($doc-url))) then concat(
       "/controller/transform.xqy?src=", $path, "&amp;", $query-string)
     (: Support /blog/atom.xml and some obsolete URLs we used to use for feeds :)
+    else if ($path = "/recipes/atom.xml") then
+      "/lib/atom.xqy?feed=recipes&amp;" || $query-string
     else if ($path =
       ("/blog/atom.xml", "/newsandevents/atom.xml",
         "/news/atom.xml", "/events/atom.xml")) then "/lib/atom.xqy"

--- a/src/lib/atom-lib.xqy
+++ b/src/lib/atom-lib.xqy
@@ -1,0 +1,28 @@
+xquery version "1.0-ml";
+
+module namespace atom = "http://www.marklogic.com/blog/atom";
+
+import module namespace s = "http://marklogic.com/rundmc/server-urls" at "/controller/server-urls.xqy";
+
+declare namespace w3atom = "http://www.w3.org/2005/Atom";
+
+declare option xdmp:mapping "false";
+
+declare function atom:feed(
+  $title as xs:string,
+  $entries as element(w3atom:entry)*
+)
+{
+  '<?xml version="1.0" encoding="UTF-8"?>',
+  <feed xmlns="http://www.w3.org/2005/Atom">
+    <title>$title</title>
+    <subtitle></subtitle>
+    <link href="{ $s:main-server }/blog/atom.xml" rel="self"/>
+    <updated>{ current-dateTime() }</updated>
+    <id></id>
+    <generator uri="{ $s:main-server }/blog/atom.xml" version="1.0">MarkLogic Community</generator>
+    <icon>{ $s:main-server }/favicon.ico</icon>
+    <logo>{ $s:main-server }/media/marklogic-community-badge.png</logo>
+    { $entries }
+  </feed>
+};

--- a/src/lib/atom-lib.xqy
+++ b/src/lib/atom-lib.xqy
@@ -4,6 +4,8 @@ module namespace atom = "http://www.marklogic.com/blog/atom";
 
 import module namespace s = "http://marklogic.com/rundmc/server-urls" at "/controller/server-urls.xqy";
 
+declare namespace ml= "http://developer.marklogic.com/site/internal";
+
 declare namespace w3atom = "http://www.w3.org/2005/Atom";
 
 declare option xdmp:mapping "false";
@@ -25,4 +27,50 @@ declare function atom:feed(
     <logo>{ $s:main-server }/media/marklogic-community-badge.png</logo>
     { $entries }
   </feed>
+};
+
+declare function atom:entry($content)
+{
+  <entry xmlns="http://www.w3.org/2005/Atom">
+    <id>{$content/ml:link/text()}</id>
+    <link>
+      {
+        attribute href {
+          let $uri := fn:base-uri($content)
+          return
+            if ((fn:starts-with($uri, "/blog/") or
+                 fn:starts-with($uri, "/news/") or
+                 fn:starts-with($uri, "/events/")) and
+                fn:ends-with($uri, ".xml")) then
+              "http://" || $s:main-server || fn:substring-before($uri, ".xml")
+            else ()
+        }
+      }
+    </link>
+    <title>{$content/ml:title/text()}</title>
+    <author><name>{$content/ml:author//text()}</name></author>
+    <updated> {
+      if ($content/ml:last-updated/fn:string()) then
+        $content/ml:last-updated/fn:string()
+      else
+        $content/ml:created/fn:string()
+    }
+    </updated>
+    <published>{ $content/ml:created/fn:string() }</published>
+    <content type="html">
+      {
+        if ($content/ml:body) then
+          xdmp:quote(
+            $content/ml:body,
+            <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>
+          )
+        else if ($content/ml:description) then
+          xdmp:quote(
+            $content/ml:description//text(),
+            <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>
+          )
+        else ()
+      }
+    </content>
+  </entry>
 };

--- a/src/lib/atom-lib.xqy
+++ b/src/lib/atom-lib.xqy
@@ -15,12 +15,12 @@ declare function atom:feed(
 {
   '<?xml version="1.0" encoding="UTF-8"?>',
   <feed xmlns="http://www.w3.org/2005/Atom">
-    <title>$title</title>
+    <title>{$title}</title>
     <subtitle></subtitle>
-    <link href="{ $s:main-server }/blog/atom.xml" rel="self"/>
+    <link href="{ $s:main-server || xdmp:get-original-url() }" rel="self"/>
     <updated>{ current-dateTime() }</updated>
     <id></id>
-    <generator uri="{ $s:main-server }/blog/atom.xml" version="1.0">MarkLogic Community</generator>
+    <generator uri="{ $s:main-server || xdmp:get-original-url() }" version="1.0">MarkLogic Community</generator>
     <icon>{ $s:main-server }/favicon.ico</icon>
     <logo>{ $s:main-server }/media/marklogic-community-badge.png</logo>
     { $entries }

--- a/src/lib/atom-lib.xqy
+++ b/src/lib/atom-lib.xqy
@@ -69,7 +69,9 @@ declare function atom:recipe-entry($recipe as element(ml:Recipe))
       <title>{$recipe/ml:title/fn:string()}</title>
       {
         $recipe/ml:author ! <author><name>{./fn:string()}</name></author>,
-        $recipe/ml:tags
+        $recipe/ml:tags,
+        $recipe/ml:min-server-version,
+        $recipe/ml:max-server-version
       }
       <updated>{$recipe/ml:last-updated/fn:string()}</updated>
       <content type="application/xml">

--- a/src/lib/atom.xqy
+++ b/src/lib/atom.xqy
@@ -35,7 +35,9 @@ return (
     return
       atom:feed(
         "MarkLogic Recipes",
-        (/ml:Recipe)[$start to $end] ! atom:entry(.),
+        for $recipe in (/ml:Recipe)[$start to $end]
+        order by $recipe/ml:last-updated descending
+        return atom:recipe-entry($recipe),
         $page, $recipe-count gt $end
       )
   else

--- a/src/lib/atom.xqy
+++ b/src/lib/atom.xqy
@@ -38,37 +38,6 @@ return (
       for $p in $posts [1 to $MAX_ENTRIES]
       order by xs:dateTime($p/ml:created/text()) descending
       return
-        <entry xmlns="http://www.w3.org/2005/Atom">
-          <id>{$p/ml:link/text()}</id>
-          <link href="{
-            let $uri := fn:base-uri($p)
-            return
-            if ( (fn:starts-with($uri, "/blog/")) and (fn:ends-with($uri, ".xml")) )
-            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-            else if ( (fn:starts-with($uri, "/news/")) and (fn:ends-with($uri, ".xml")) )
-            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-            else if ( (fn:starts-with($uri, "/events/")) and (fn:ends-with($uri, ".xml")) )
-            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-            else ()
-          }"/>
-          <title>{$p/ml:title/text()}</title>
-          <author><name>{$p/ml:author//text()}</name></author>
-          <updated> {
-            if ($p/ml:last-updated/text())
-            then $p/ml:last-updated/text()
-            else string($p/ml:created/text())
-          }
-          </updated>
-          <published>{ string($p/ml:created/text()) }</published>
-          <content type="html">
-            {
-              if ($p/ml:body)
-              then xdmp:quote($p/ml:body, <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
-              else if ($p/ml:description)
-              then xdmp:quote($p/ml:description//text(), <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
-              else ()
-            }
-          </content>
-        </entry>
+        atom:entry($p)
     )
 )

--- a/src/lib/atom.xqy
+++ b/src/lib/atom.xqy
@@ -1,20 +1,21 @@
 xquery version "1.0-ml";
 
-declare namespace atom="http://www.marklogic.com/blog/atom";
+import module namespace atom = "http://www.marklogic.com/blog/atom" at "atom-lib.xqy";
+
 declare namespace ml= "http://developer.marklogic.com/site/internal";
 declare default function namespace "http://www.w3.org/2005/xpath-functions";
 
 declare function atom:fakedLikeZulu($dt as xs:dateTime) as xs:dateTime {
-    $dt - implicit-timezone()
+  $dt - implicit-timezone()
 };
 
 declare function atom:expireInSeconds ($s as xs:integer) as empty-sequence() {
-    let $DATE_HEADER := "%a, %d %b %Y %H:%M:%S"
-    let $duration := xs:dayTimeDuration(concat("PT", string($s), "S"))
-    let $set := xdmp:add-response-header("Date", xdmp:strftime($DATE_HEADER, atom:fakedLikeZulu(current-dateTime())))
-    let $set := xdmp:add-response-header("Expires", xdmp:strftime($DATE_HEADER, atom:fakedLikeZulu(current-dateTime() + $duration)))
-    let $public := xdmp:add-response-header("Cache-Control", "public")
-    return ()
+  let $DATE_HEADER := "%a, %d %b %Y %H:%M:%S"
+  let $duration := xs:dayTimeDuration(concat("PT", string($s), "S"))
+  let $set := xdmp:add-response-header("Date", xdmp:strftime($DATE_HEADER, atom:fakedLikeZulu(current-dateTime())))
+  let $set := xdmp:add-response-header("Expires", xdmp:strftime($DATE_HEADER, atom:fakedLikeZulu(current-dateTime() + $duration)))
+  let $public := xdmp:add-response-header("Cache-Control", "public")
+  return ()
 };
 
 
@@ -23,66 +24,51 @@ xdmp:set-response-content-type("application/atom+xml; charset=utf-8"),
 let $MAX_ENTRIES := 30
 let $expires := atom:expireInSeconds(60 * 60)
 let $feed := xdmp:get-request-field("feed", "")
-
-
-
-return
-('<?xml version="1.0" encoding="UTF-8"?>',
-    let $posts :=
-        for $r in (fn:doc()/ml:Post[@status="Published"], 
-                   fn:doc()/ml:Announcement[@status="Published"], 
-                   fn:doc()/ml:Event[@status="Published"])
-        where not(starts-with(base-uri($r), "/preview"))
-        order by xs:dateTime($r/ml:created/text()) descending
-        return $r
-    return
-    <feed xmlns="http://www.w3.org/2005/Atom">
-    	<title>MarkLogic Community Blog</title>
-    	<subtitle></subtitle>
-    	<link href="http://developer.marklogic.com/blog/atom.xml" rel="self"/>
-    	<updated>{ current-dateTime() }</updated>
-    	<id></id>
-    
-    	<generator uri="http://developer.marklogic.com/blog/atom.xml" version="1.0">MarkLogic Community</generator>
-    	<icon>http://developer.marklogic.com/favicon.ico</icon>
-    	<logo>http://developer.marklogic.com/media/marklogic-community-badge.png</logo>
-    	{
-            for $p in $posts [1 to $MAX_ENTRIES]
-            order by xs:dateTime($p/ml:created/text()) descending 
+return (
+  let $posts :=
+    for $r in (fn:doc()/ml:Post[@status="Published"],
+               fn:doc()/ml:Announcement[@status="Published"],
+               fn:doc()/ml:Event[@status="Published"])
+    where not(starts-with(base-uri($r), "/preview"))
+    order by xs:dateTime($r/ml:created/text()) descending
+    return $r
+  return
+    atom:feed(
+      "MarkLogic Community Blog",
+      for $p in $posts [1 to $MAX_ENTRIES]
+      order by xs:dateTime($p/ml:created/text()) descending
+      return
+        <entry xmlns="http://www.w3.org/2005/Atom">
+          <id>{$p/ml:link/text()}</id>
+          <link href="{
+            let $uri := fn:base-uri($p)
             return
-            <entry>
-                <id>{$p/ml:link/text()}</id>
-                <link href="{
-                    let $uri := fn:base-uri($p)
-                    return
-                    if ( (fn:starts-with($uri, "/blog/")) and (fn:ends-with($uri, ".xml")) )
-                    then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-                    else if ( (fn:starts-with($uri, "/news/")) and (fn:ends-with($uri, ".xml")) )
-                    then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-                    else if ( (fn:starts-with($uri, "/events/")) and (fn:ends-with($uri, ".xml")) )
-                    then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
-                    else ()
-                }"/>
-                <title>{$p/ml:title/text()}</title>
-                <author><name>{$p/ml:author//text()}</name></author>
-                <updated>   {
-                    if ($p/ml:last-updated/text())
-                    then $p/ml:last-updated/text()
-                    else string($p/ml:created/text())
-                }
-                </updated>
-                <published>{ string($p/ml:created/text()) }</published>
-                <content type="html">
-                    { 
-                    if ($p/ml:body) 
-                    then xdmp:quote($p/ml:body, <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
-                    else if ($p/ml:description)
-                    then xdmp:quote($p/ml:description//text(), <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
-                    else ()
-                    }
-                </content>
-            </entry>
-    	}
-    </feed>,
-    ()
+            if ( (fn:starts-with($uri, "/blog/")) and (fn:ends-with($uri, ".xml")) )
+            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
+            else if ( (fn:starts-with($uri, "/news/")) and (fn:ends-with($uri, ".xml")) )
+            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
+            else if ( (fn:starts-with($uri, "/events/")) and (fn:ends-with($uri, ".xml")) )
+            then fn:concat( "http://",xdmp:host-name(), fn:substring ($uri,1, string-length($uri) - string-length(".xml") ) )
+            else ()
+          }"/>
+          <title>{$p/ml:title/text()}</title>
+          <author><name>{$p/ml:author//text()}</name></author>
+          <updated> {
+            if ($p/ml:last-updated/text())
+            then $p/ml:last-updated/text()
+            else string($p/ml:created/text())
+          }
+          </updated>
+          <published>{ string($p/ml:created/text()) }</published>
+          <content type="html">
+            {
+              if ($p/ml:body)
+              then xdmp:quote($p/ml:body, <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
+              else if ($p/ml:description)
+              then xdmp:quote($p/ml:description//text(), <options xmlns="xdmp:quote"><output-encoding>utf-8</output-encoding></options>)
+              else ()
+            }
+          </content>
+        </entry>
+    )
 )

--- a/src/lib/atom.xqy
+++ b/src/lib/atom.xqy
@@ -31,7 +31,6 @@ return (
     let $recipe-count := xdmp:estimate(/ml:Recipe)
     let $start := ($page - 1) * $page-size + 1
     let $end := $start + $page-size - 1
-    let $_ := xdmp:log("atom: feed=" || $feed || "; start=" || $start || "; end=" || $end)
     return
       atom:feed(
         "MarkLogic Recipes",


### PR DESCRIPTION
Kept original functionality, which covered blogs, announcements, and events. Implemented new feed for Recipes. Verified that /recipes/atom.xml produces valid Atom XML.